### PR TITLE
Fix bugs and update modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/ceshihao/windowsupdate
 
 go 1.15
 
-require github.com/go-ole/go-ole v1.2.4
+require github.com/go-ole/go-ole v1.2.6

--- a/icategory.go
+++ b/icategory.go
@@ -19,7 +19,7 @@ import (
 )
 
 // ICategory represents the category to which an update belongs.
-// https://docs.microsoft.com/zh-cn/windows/win32/api/wuapi/nn-wuapi-icategory
+// https://docs.microsoft.com/en-us/windows/win32/api/wuapi/nn-wuapi-icategory
 type ICategory struct {
 	disp        *ole.IDispatch
 	CategoryID  string

--- a/iimageinformation.go
+++ b/iimageinformation.go
@@ -18,7 +18,7 @@ import (
 )
 
 // IImageInformation contains information about a localized image that is associated with an update or a category.
-// https://docs.microsoft.com/zh-cn/windows/win32/api/wuapi/nn-wuapi-iimageinformation
+// https://docs.microsoft.com/en-us/windows/win32/api/wuapi/nn-wuapi-iimageinformation
 type IImageInformation struct {
 	disp    *ole.IDispatch
 	AltText string

--- a/iinstallationbehavior.go
+++ b/iinstallationbehavior.go
@@ -18,12 +18,12 @@ import (
 )
 
 // IInstallationBehavior represents the installation and uninstallation options of an update.
-// https://docs.microsoft.com/zh-cn/windows/win32/api/wuapi/nn-wuapi-iinstallationbehavior
+// https://docs.microsoft.com/en-us/windows/win32/api/wuapi/nn-wuapi-iinstallationbehavior
 type IInstallationBehavior struct {
 	disp                        *ole.IDispatch
 	CanRequestUserInput         bool
-	Impact                      int32 // enum https://docs.microsoft.com/zh-cn/windows/win32/api/wuapi/ne-wuapi-installationimpact
-	RebootBehavior              int32 // enum https://docs.microsoft.com/zh-cn/windows/win32/api/wuapi/ne-wuapi-installationrebootbehavior
+	Impact                      int32 // enum https://docs.microsoft.com/en-us/windows/win32/api/wuapi/ne-wuapi-installationimpact
+	RebootBehavior              int32 // enum https://docs.microsoft.com/en-us/windows/win32/api/wuapi/ne-wuapi-installationrebootbehavior
 	RequiresNetworkConnectivity bool
 }
 

--- a/isearchresult.go
+++ b/isearchresult.go
@@ -19,10 +19,10 @@ import (
 )
 
 // ISearchResult represents the result of a search.
-// https://docs.microsoft.com/zh-cn/windows/win32/api/wuapi/nn-wuapi-isearchresult
+// https://docs.microsoft.com/en-us/windows/win32/api/wuapi/nn-wuapi-isearchresult
 type ISearchResult struct {
 	disp           *ole.IDispatch
-	ResultCode     int32 // enum https://docs.microsoft.com/zh-cn/windows/win32/api/wuapi/ne-wuapi-operationresultcode
+	ResultCode     int32 // enum https://docs.microsoft.com/en-us/windows/win32/api/wuapi/ne-wuapi-operationresultcode
 	RootCategories []*ICategory
 	Updates        []*IUpdate
 	Warnings       []*IUpdateException

--- a/istringcollection.go
+++ b/istringcollection.go
@@ -1,0 +1,34 @@
+package windowsupdate
+
+import (
+	"github.com/go-ole/go-ole"
+	"github.com/go-ole/go-ole/oleutil"
+)
+
+// https://docs.microsoft.com/en-us/windows/win32/api/wuapi/nn-wuapi-istringcollection
+func iStringCollectionToStringArrayErr(disp *ole.IDispatch, err error) ([]string, error) {
+	if err != nil {
+		return nil, err
+	}
+
+	if disp == nil {
+		return nil, nil
+	}
+
+	count, err := toInt32Err(oleutil.GetProperty(disp, "Count"))
+	if err != nil {
+		return nil, err
+	}
+
+	stringCollection := make([]string, count)
+
+	for i := 0; i < int(count); i++ {
+		str, err := toStringErr(oleutil.GetProperty(disp, "Item", i))
+		if err != nil {
+			return nil, err
+		}
+
+		stringCollection[i] = str
+	}
+	return stringCollection, nil
+}

--- a/iupdate.go
+++ b/iupdate.go
@@ -100,7 +100,7 @@ func toIUpdate(updateDisp *ole.IDispatch) (*IUpdate, error) {
 		return nil, err
 	}
 
-	if iUpdate.BundledUpdates, err = toStringSliceErr(oleutil.GetProperty(updateDisp, "BundledUpdates")); err != nil {
+	if iUpdate.BundledUpdates, err = iStringCollectionToStringArrayErr(toIDispatchErr(oleutil.GetProperty(updateDisp, "BundledUpdates"))); err != nil {
 		return nil, err
 	}
 
@@ -218,11 +218,11 @@ func toIUpdate(updateDisp *ole.IDispatch) (*IUpdate, error) {
 		return nil, err
 	}
 
-	if iUpdate.KBArticleIDs, err = toStringSliceErr(oleutil.GetProperty(updateDisp, "KBArticleIDs")); err != nil {
+	if iUpdate.KBArticleIDs, err = iStringCollectionToStringArrayErr(toIDispatchErr(oleutil.GetProperty(updateDisp, "KBArticleIDs"))); err != nil {
 		return nil, err
 	}
 
-	if iUpdate.Languages, err = toStringSliceErr(oleutil.GetProperty(updateDisp, "Languages")); err != nil {
+	if iUpdate.Languages, err = iStringCollectionToStringArrayErr(toIDispatchErr(oleutil.GetProperty(updateDisp, "Languages"))); err != nil {
 		return nil, err
 	}
 
@@ -238,7 +238,7 @@ func toIUpdate(updateDisp *ole.IDispatch) (*IUpdate, error) {
 		return nil, err
 	}
 
-	if iUpdate.MoreInfoUrls, err = toStringSliceErr(oleutil.GetProperty(updateDisp, "MoreInfoUrls")); err != nil {
+	if iUpdate.MoreInfoUrls, err = iStringCollectionToStringArrayErr(toIDispatchErr(oleutil.GetProperty(updateDisp, "MoreInfoUrls"))); err != nil {
 		return nil, err
 	}
 
@@ -262,11 +262,11 @@ func toIUpdate(updateDisp *ole.IDispatch) (*IUpdate, error) {
 		return nil, err
 	}
 
-	if iUpdate.SecurityBulletinIDs, err = toStringSliceErr(oleutil.GetProperty(updateDisp, "SecurityBulletinIDs")); err != nil {
+	if iUpdate.SecurityBulletinIDs, err = iStringCollectionToStringArrayErr(toIDispatchErr(oleutil.GetProperty(updateDisp, "SecurityBulletinIDs"))); err != nil {
 		return nil, err
 	}
 
-	if iUpdate.SupersededUpdateIDs, err = toStringSliceErr(oleutil.GetProperty(updateDisp, "SupersededUpdateIDs")); err != nil {
+	if iUpdate.SupersededUpdateIDs, err = iStringCollectionToStringArrayErr(toIDispatchErr(oleutil.GetProperty(updateDisp, "SupersededUpdateIDs"))); err != nil {
 		return nil, err
 	}
 
@@ -292,7 +292,7 @@ func toIUpdate(updateDisp *ole.IDispatch) (*IUpdate, error) {
 		return nil, err
 	}
 
-	if iUpdate.UninstallationSteps, err = toStringSliceErr(oleutil.GetProperty(updateDisp, "UninstallationSteps")); err != nil {
+	if iUpdate.UninstallationSteps, err = iStringCollectionToStringArrayErr(toIDispatchErr(oleutil.GetProperty(updateDisp, "UninstallationSteps"))); err != nil {
 		return nil, err
 	}
 

--- a/iupdate.go
+++ b/iupdate.go
@@ -21,7 +21,7 @@ import (
 )
 
 // IUpdate contains the properties and methods that are available to an update.
-// https://docs.microsoft.com/zh-cn/windows/win32/api/wuapi/nn-wuapi-iupdate
+// https://docs.microsoft.com/en-us/windows/win32/api/wuapi/nn-wuapi-iupdate
 type IUpdate struct {
 	disp                            *ole.IDispatch
 	AutoSelectOnWebSites            bool
@@ -31,10 +31,10 @@ type IUpdate struct {
 	Deadline                        *time.Time
 	DeltaCompressedContentAvailable bool
 	DeltaCompressedContentPreferred bool
-	DeploymentAction                int32 // enum https://docs.microsoft.com/zh-cn/windows/win32/api/wuapi/ne-wuapi-deploymentaction
+	DeploymentAction                int32 // enum https://docs.microsoft.com/en-us/windows/win32/api/wuapi/ne-wuapi-deploymentaction
 	Description                     string
 	DownloadContents                []*IUpdateDownloadContent
-	DownloadPriority                int32 // enum https://docs.microsoft.com/zh-cn/windows/win32/api/wuapi/ne-wuapi-downloadpriority
+	DownloadPriority                int32 // enum https://docs.microsoft.com/en-us/windows/win32/api/wuapi/ne-wuapi-downloadpriority
 	EulaAccepted                    bool
 	EulaText                        string
 	HandlerID                       string

--- a/iupdatedownloadcontent.go
+++ b/iupdatedownloadcontent.go
@@ -18,7 +18,7 @@ import (
 )
 
 // IUpdateDownloadContent represents the download content of an update.
-// https://docs.microsoft.com/zh-cn/windows/win32/api/wuapi/nn-wuapi-iupdatedownloadcontent
+// https://docs.microsoft.com/en-us/windows/win32/api/wuapi/nn-wuapi-iupdatedownloadcontent
 type IUpdateDownloadContent struct {
 	disp        *ole.IDispatch
 	DownloadUrl string

--- a/iupdateexception.go
+++ b/iupdateexception.go
@@ -18,10 +18,10 @@ import (
 )
 
 // IUpdateException represents info about the aspects of search results returned in the ISearchResult object that were incomplete. For more info, see Remarks.
-// https://docs.microsoft.com/zh-cn/windows/win32/api/wuapi/nn-wuapi-iupdateexception
+// https://docs.microsoft.com/en-us/windows/win32/api/wuapi/nn-wuapi-iupdateexception
 type IUpdateException struct {
 	disp    *ole.IDispatch
-	Context int32 // enum https://docs.microsoft.com/zh-cn/windows/win32/api/wuapi/ne-wuapi-updateexceptioncontext
+	Context int32 // enum https://docs.microsoft.com/en-us/windows/win32/api/wuapi/ne-wuapi-updateexceptioncontext
 	HResult int64
 	Message string
 }

--- a/iupdatehistoryentry.go
+++ b/iupdatehistoryentry.go
@@ -21,7 +21,7 @@ import (
 )
 
 // IUpdateHistoryEntry represents the recorded history of an update.
-// https://docs.microsoft.com/zh-cn/windows/win32/api/wuapi/nn-wuapi-iupdatehistoryentry
+// https://docs.microsoft.com/en-us/windows/win32/api/wuapi/nn-wuapi-iupdatehistoryentry
 type IUpdateHistoryEntry struct {
 	disp                *ole.IDispatch
 	ClientApplicationID string

--- a/iupdatehistoryentry.go
+++ b/iupdatehistoryentry.go
@@ -113,7 +113,7 @@ func toIUpdateHistoryEntry(updateHistoryEntryDisp *ole.IDispatch) (*IUpdateHisto
 		return nil, err
 	}
 
-	if iUpdateHistoryEntry.UninstallationSteps, err = toStringSliceErr(oleutil.GetProperty(updateHistoryEntryDisp, "UninstallationSteps")); err != nil {
+	if iUpdateHistoryEntry.UninstallationSteps, err = iStringCollectionToStringArrayErr(toIDispatchErr(oleutil.GetProperty(updateHistoryEntryDisp, "UninstallationSteps"))); err != nil {
 		return nil, err
 	}
 

--- a/iupdateidentity.go
+++ b/iupdateidentity.go
@@ -19,7 +19,7 @@ import (
 )
 
 // IUpdateIdentity represents the unique identifier of an update.
-// https://docs.microsoft.com/zh-cn/windows/win32/api/wuapi/nn-wuapi-iupdateidentity
+// https://docs.microsoft.com/en-us/windows/win32/api/wuapi/nn-wuapi-iupdateidentity
 type IUpdateIdentity struct {
 	disp           *ole.IDispatch
 	RevisionNumber int32

--- a/iupdatesearcher.go
+++ b/iupdatesearcher.go
@@ -19,7 +19,7 @@ import (
 )
 
 // IUpdateSearcher searches for updates on a server.
-// https://docs.microsoft.com/zh-cn/windows/win32/api/wuapi/nn-wuapi-iupdatesearcher
+// https://docs.microsoft.com/en-us/windows/win32/api/wuapi/nn-wuapi-iupdatesearcher
 type IUpdateSearcher struct {
 	disp                                *ole.IDispatch
 	CanAutomaticallyUpgradeService      bool
@@ -64,7 +64,7 @@ func toIUpdateSearcher(updateSearcherDisp *ole.IDispatch) (*IUpdateSearcher, err
 }
 
 // Search performs a synchronous search for updates. The search uses the search options that are currently configured.
-// https://docs.microsoft.com/zh-cn/windows/win32/api/wuapi/nf-wuapi-iupdatesearcher-search
+// https://docs.microsoft.com/en-us/windows/win32/api/wuapi/nf-wuapi-iupdatesearcher-search
 func (iUpdateSearcher *IUpdateSearcher) Search(criteria string) (*ISearchResult, error) {
 	searchResultDisp, err := toIDispatchErr(oleutil.CallMethod(iUpdateSearcher.disp, "Search", criteria))
 	if err != nil {
@@ -74,7 +74,7 @@ func (iUpdateSearcher *IUpdateSearcher) Search(criteria string) (*ISearchResult,
 }
 
 // QueryHistory synchronously queries the computer for the history of the update events.
-// https://docs.microsoft.com/zh-cn/windows/win32/api/wuapi/nf-wuapi-iupdatesearcher-queryhistory
+// https://docs.microsoft.com/en-us/windows/win32/api/wuapi/nf-wuapi-iupdatesearcher-queryhistory
 func (iUpdateSearcher *IUpdateSearcher) QueryHistory(startIndex int32, count int32) ([]*IUpdateHistoryEntry, error) {
 	updateHistoryEntriesDisp, err := toIDispatchErr(oleutil.CallMethod(iUpdateSearcher.disp, "QueryHistory", startIndex, count))
 	if err != nil {

--- a/iupdatesession.go
+++ b/iupdatesession.go
@@ -20,7 +20,7 @@ import (
 
 // IUpdateSession represents a session in which the caller can perform operations that involve updates.
 // For example, this interface represents sessions in which the caller performs a search, download, installation, or uninstallation operation.
-// https://docs.microsoft.com/zh-cn/windows/win32/api/wuapi/nn-wuapi-iupdatesession
+// https://docs.microsoft.com/en-us/windows/win32/api/wuapi/nn-wuapi-iupdatesession
 type IUpdateSession struct {
 	disp                *ole.IDispatch
 	ClientApplicationID string
@@ -69,7 +69,7 @@ func NewUpdateSession() (*IUpdateSession, error) {
 }
 
 // CreateUpdateDownloader returns an IUpdateDownloader interface for this session.
-// https://docs.microsoft.com/zh-cn/windows/win32/api/wuapi/nf-wuapi-iupdatesession-createupdatedownloader
+// https://docs.microsoft.com/en-us/windows/win32/api/wuapi/nf-wuapi-iupdatesession-createupdatedownloader
 func (iUpdateSession *IUpdateSession) CreateUpdateDownloader() (*IUpdateDownloader, error) {
 	updateDownloaderDisp, err := toIDispatchErr(oleutil.CallMethod(iUpdateSession.disp, "CreateUpdateDownloader"))
 	if err != nil {
@@ -79,7 +79,7 @@ func (iUpdateSession *IUpdateSession) CreateUpdateDownloader() (*IUpdateDownload
 }
 
 // CreateUpdateInstaller returns an IUpdateInstaller interface for this session.
-// https://docs.microsoft.com/zh-cn/windows/win32/api/wuapi/nf-wuapi-iupdatesession-createupdateinstaller
+// https://docs.microsoft.com/en-us/windows/win32/api/wuapi/nf-wuapi-iupdatesession-createupdateinstaller
 func (iUpdateSession *IUpdateSession) CreateUpdateInstaller() (*IUpdateInstaller, error) {
 	updateInstallerDisp, err := toIDispatchErr(oleutil.CallMethod(iUpdateSession.disp, "CreateUpdateInstaller"))
 	if err != nil {
@@ -89,7 +89,7 @@ func (iUpdateSession *IUpdateSession) CreateUpdateInstaller() (*IUpdateInstaller
 }
 
 // CreateUpdateSearcher returns an IUpdateSearcher interface for this session.
-// https://docs.microsoft.com/zh-cn/windows/win32/api/wuapi/nf-wuapi-iupdatesession-createupdatesearcher
+// https://docs.microsoft.com/en-us/windows/win32/api/wuapi/nf-wuapi-iupdatesession-createupdatesearcher
 func (iUpdateSession *IUpdateSession) CreateUpdateSearcher() (*IUpdateSearcher, error) {
 	updateSearcherDisp, err := toIDispatchErr(oleutil.CallMethod(iUpdateSession.disp, "CreateUpdateSearcher"))
 	if err != nil {

--- a/iwebproxy.go
+++ b/iwebproxy.go
@@ -18,7 +18,7 @@ import (
 )
 
 // IWebProxy contains the HTTP proxy settings.
-// https://docs.microsoft.com/zh-cn/windows/win32/api/wuapi/nn-wuapi-iwebproxy
+// https://docs.microsoft.com/en-us/windows/win32/api/wuapi/nn-wuapi-iwebproxy
 type IWebProxy struct {
 	disp               *ole.Dispatch
 	Address            string

--- a/oleconv.go
+++ b/oleconv.go
@@ -26,17 +26,6 @@ func toIDispatchErr(result *ole.VARIANT, err error) (*ole.IDispatch, error) {
 	return result.ToIDispatch(), nil
 }
 
-func toStringSliceErr(result *ole.VARIANT, err error) ([]string, error) {
-	if err != nil {
-		return nil, err
-	}
-	array := result.ToArray()
-	if array == nil {
-		return nil, nil
-	}
-	return array.ToStringArray(), nil
-}
-
 func toInt64Err(result *ole.VARIANT, err error) (int64, error) {
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
1.  The following property was always null in `toIUpdate()`, fixed 1b6766d2ea270ac39c29f3782b4dea4a490ca96a af74e0f57f00a5931cdd1f311d250e085e6b93b1
- BundledUpdates
- KBArticleIDs
- Languages
- MoreInfoUrls
- SecurityBulletinIDs
- SupersededUpdateIDs
- UninstallationSteps

2. The following property was always null in `toIUpdateHistoryEntry()`, fixed. 318af10175edb5db9cb406d24ccd4494981363fa
- UninstallationSteps

3. Update go-ole/go-ole v1.2.4 -> v1.2.6 https://github.com/ceshihao/windowsupdate/commit/b95ac5f0ceaf3c0e12d22afc55e396538710ed60
4. Fix docs urls zh-cn -> en-us https://github.com/ceshihao/windowsupdate/commit/b0b1c8e4fa47143bde18a422abd493fb5b13730a

