### PR TITLE
Fix not exist WebProxy property

### DIFF
--- a/iupdatesession.go
+++ b/iupdatesession.go
@@ -44,7 +44,8 @@ func toIUpdateSession(updateSessionDisp *ole.IDispatch) (*IUpdateSession, error)
 
 	webProxyDisp, err := toIDispatchErr(oleutil.GetProperty(updateSessionDisp, "WebProxy"))
 	if err != nil {
-		return nil, err
+		// WebProxy property may not exist in EC2 instances
+		return iUpdateSession, nil
 	}
 	if webProxyDisp != nil {
 		if iUpdateSession.WebProxy, err = toIWebProxy(webProxyDisp); err != nil {


### PR DESCRIPTION
Signed-off-by: re3turn <re3turn@gmail.com>


The WebProxy property may not exist on the EC2 instance and `GetProperty()` fails.
```
PS C:/Users/re3turn/GolandProjects/wsus/windowsupdate/examples> .\install_updates.exe
panic: Exception occurred. (<nil>)

goroutine 1 [running]:
main.main()
        C:/Users/re3turn/GolandProjects/wsus/windowsupdate/examples/install_updates/main.go:24 +0x194
```